### PR TITLE
fix(bmx): clear latched interrupt before mapping motion engine to pins

### DIFF
--- a/internal/bmx/hardware_controller.go
+++ b/internal/bmx/hardware_controller.go
@@ -158,11 +158,31 @@ func (c *HardwareController) SoftReset(ctx context.Context) error {
 	return nil
 }
 
-// EnableInterrupt maps interrupt pins and enables the poller for the current mode.
-// Must be called after ConfigureSensor. Clears any stale latched interrupt first
-// to avoid false triggers from filter-settling transients during configuration.
+// EnableInterrupt enables the poller for the current mode and maps the motion
+// engine to the INT pins. Must be called after ConfigureSensor.
+//
+// Ordering matters: the bandwidth change in ConfigureSensor kicks off a
+// low-pass filter settle that can produce a transient slope large enough to
+// set the status bit. If the pin mapping is in place while that transient
+// latches, the INT line spikes from a stale status bit and the gpio-keys
+// edge already fires before the status is cleared — which both gives a false
+// wake and hides the real first bump from the poller (since it has not been
+// enabled yet). Clear twice across a filter-settle delay *before* adding the
+// engine to the pin map, so the first sample the map sees reflects reality.
+// One sample period is 32 ms at 31.25 Hz and 64 ms at 15.63 Hz; 100 ms covers
+// all bandwidths in use with margin.
 func (c *HardwareController) EnableInterrupt(ctx context.Context) error {
 	c.log.Info("enabling interrupt", "mode", c.currentMode.String())
+
+	if err := c.accel.ClearLatchedInterrupt(); err != nil {
+		c.log.Warn("failed to clear latched interrupt before settle", "error", err)
+	}
+
+	time.Sleep(100 * time.Millisecond)
+
+	if err := c.accel.ClearLatchedInterrupt(); err != nil {
+		c.log.Warn("failed to clear latched interrupt after settle", "error", err)
+	}
 
 	if c.currentMode == hwbmx.InterruptModeAnyMotion {
 		if err := c.accel.MapAnyMotionToPins(hwbmx.InterruptPinBoth); err != nil {
@@ -172,20 +192,6 @@ func (c *HardwareController) EnableInterrupt(ctx context.Context) error {
 		if err := c.accel.EnableSlowNoMotionInterrupt(true); err != nil {
 			return fmt.Errorf("failed to enable slow-motion interrupt: %w", err)
 		}
-	}
-
-	if err := c.accel.ClearLatchedInterrupt(); err != nil {
-		c.log.Warn("failed to clear latched interrupt before enabling poller", "error", err)
-	}
-
-	// Wait for the low-pass filter to settle after bandwidth change, then clear
-	// again. The first samples after reconfiguration can produce a transient slope
-	// that triggers a false interrupt. One sample period is sufficient (32ms at
-	// 31.25 Hz, 64ms at 15.63 Hz); 100ms covers all bandwidths with margin.
-	time.Sleep(100 * time.Millisecond)
-
-	if err := c.accel.ClearLatchedInterrupt(); err != nil {
-		c.log.Warn("failed to clear latched interrupt after settle", "error", err)
 	}
 
 	c.poller.Enable()


### PR DESCRIPTION
`EnableInterrupt` currently maps any-motion to the INT pins *and then* clears the latched interrupt. That lets a filter-settling transient from the bandwidth change in `ConfigureSensor` set the slope status bit before the clear runs. Since the slope bit is already in `INT_MAP_0` at that point, the INT line goes high immediately from a stale status bit — the gpio-keys edge fires, the subsequent `ClearLatchedInterrupt` wipes the status, and the poller never sees the triggered state because it hasn't been enabled yet.

Observed on target: every disarm → armed transition added ~2 edges to `/proc/interrupts` on the INT1 GPIO without any `"motion interrupt detected"` log, giving the impression of motion that the poller then "missed". It wasn't missed — the status was cleared before the poller could read it.

## Fix

Reorder so the two clears (pre- and post-settle) run *before* the engine is mapped to the pin. After the 100 ms settle the filter is stable, so the first sample the map sees reflects real motion.

## Verified on target

Across a full `disarmed -> delay_armed -> armed` cycle:

```
# before fix
156:  2  gpio-mxc  22  Edge  GPIO Key ACC_INT1   # after 1 rearm cycle

# after fix
156:  2  gpio-mxc  22  Edge  GPIO Key ACC_INT1   # baseline
# runtime disarm + arm
156:  2  gpio-mxc  22  Edge  GPIO Key ACC_INT1   # unchanged
```

The `"enabling interrupt"` -> `"interrupt monitoring enabled"` log delta is ~110 ms before and after, so no regression from the reorder.