### PR TITLE
feat(alarm): read motion IRQ via evdev, drop poller to watchdog rate

### DIFF
--- a/cmd/alarm-service/main.go
+++ b/cmd/alarm-service/main.go
@@ -25,6 +25,9 @@ func main() {
 	hairTrigger := flag.Bool("hair-trigger", false, "Enable hair trigger mode (immediate short alarm on first motion)")
 	hairTriggerDuration := flag.Int("hair-trigger-duration", 3, "Hair trigger alarm duration in seconds")
 	l1Cooldown := flag.Int("l1-cooldown", 5, "Level 1 cooldown duration in seconds")
+	evdevDevice := flag.String("evdev-device", "/dev/input/by-path/platform-gpio-keys-event", "Input device for the BMX055 INT1 gpio-keys edge (empty to disable and use poller only)")
+	evdevKeycode := flag.Int("evdev-keycode", 0x2b, "Keycode from gpio-keys device that corresponds to BMX055 INT1")
+	pollerIntervalMs := flag.Int("poller-interval-ms", 1000, "Interval in ms between I2C status polls. Used as a watchdog when the evdev path is active; primary source when evdev is disabled")
 	versionFlag := flag.Bool("version", false, "Print version and exit")
 	flag.Parse()
 
@@ -80,7 +83,10 @@ func main() {
 		"seatbox_trigger", *seatboxTrigger,
 		"hair_trigger", *hairTrigger,
 		"hair_trigger_duration", *hairTriggerDuration,
-		"l1_cooldown", *l1Cooldown)
+		"l1_cooldown", *l1Cooldown,
+		"evdev_device", *evdevDevice,
+		"evdev_keycode", *evdevKeycode,
+		"poller_interval_ms", *pollerIntervalMs)
 
 	application := app.New(&app.Config{
 		I2CBus:                     *i2cBus,
@@ -100,6 +106,9 @@ func main() {
 		HairTriggerDurationFlagSet: hairTriggerDurationFlagSet,
 		L1Cooldown:                 *l1Cooldown,
 		L1CooldownFlagSet:          l1CooldownFlagSet,
+		EvdevDevice:                *evdevDevice,
+		EvdevKeycode:               *evdevKeycode,
+		PollerIntervalMs:           *pollerIntervalMs,
 	})
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -35,22 +35,26 @@ type Config struct {
 	HairTriggerDurationFlagSet bool
 	L1Cooldown                 int
 	L1CooldownFlagSet          bool
+	EvdevDevice                string
+	EvdevKeycode               int
+	PollerIntervalMs           int
 }
 
 // App represents the alarm-service application
 type App struct {
-	cfg             *Config
-	log             *slog.Logger
-	redis           *redis.Client
-	publisher       *redis.Publisher
-	accel           *hwbmx.Accelerometer
-	gyro            *hwbmx.Gyroscope
-	bmxController   *bmx.HardwareController
-	interruptPoller *hardware.InterruptPoller
-	alarmController *alarm.Controller
-	inhibitor       *pm.Inhibitor
-	stateMachine    *fsm.StateMachine
-	subscriber      *redis.Subscriber
+	cfg              *Config
+	log              *slog.Logger
+	redis            *redis.Client
+	publisher        *redis.Publisher
+	accel            *hwbmx.Accelerometer
+	gyro             *hwbmx.Gyroscope
+	bmxController    *bmx.HardwareController
+	interruptPoller  *hardware.InterruptPoller
+	interruptWatcher *hardware.InterruptWatcher
+	alarmController  *alarm.Controller
+	inhibitor        *pm.Inhibitor
+	stateMachine     *fsm.StateMachine
+	subscriber       *redis.Subscriber
 }
 
 // New creates a new App
@@ -88,10 +92,31 @@ func (a *App) Run(ctx context.Context) error {
 	}
 	defer a.closeBMXHardware()
 
-	a.interruptPoller = hardware.NewInterruptPoller(a.accel, a.gyro, a.publisher, a.log)
+	a.interruptPoller = hardware.NewInterruptPoller(a.accel, a.gyro, a.publisher, time.Duration(a.cfg.PollerIntervalMs)*time.Millisecond, a.log)
 	go a.interruptPoller.Run(ctx)
 
-	a.bmxController = bmx.NewHardwareController(a.accel, a.gyro, a.interruptPoller, a.log)
+	var watcherSource interface {
+		Enable()
+		Disable()
+	}
+	if a.cfg.EvdevDevice != "" {
+		a.interruptWatcher = hardware.NewInterruptWatcher(
+			a.cfg.EvdevDevice,
+			uint16(a.cfg.EvdevKeycode),
+			a.accel,
+			a.publisher,
+			a.log,
+		)
+		if err := a.interruptWatcher.Open(); err != nil {
+			a.log.Warn("evdev interrupt watcher disabled (falling back to poller only)", "error", err)
+			a.interruptWatcher = nil
+		} else {
+			watcherSource = a.interruptWatcher
+			go a.interruptWatcher.Run(ctx)
+		}
+	}
+
+	a.bmxController = bmx.NewHardwareController(a.accel, a.gyro, a.interruptPoller, watcherSource, a.log)
 
 	a.alarmController, err = alarm.NewController(a.cfg.RedisAddr, a.cfg.HornEnabled, a.log)
 	if err != nil {

--- a/internal/bmx/hardware_controller.go
+++ b/internal/bmx/hardware_controller.go
@@ -38,8 +38,9 @@ type Gyroscope interface {
 	SoftReset() error
 }
 
-// InterruptPoller interface for enabling/disabling interrupt polling
-type InterruptPoller interface {
+// InterruptSource is something that can be gated in lockstep with the BMX055
+// mapping changes — the I2C poller and the evdev watcher both implement it.
+type InterruptSource interface {
 	Enable()
 	Disable()
 }
@@ -48,18 +49,22 @@ type InterruptPoller interface {
 type HardwareController struct {
 	accel       Accelerometer
 	gyro        Gyroscope
-	poller      InterruptPoller
+	poller      InterruptSource
+	watcher     InterruptSource
 	log         *slog.Logger
 	currentMode hwbmx.InterruptMode
 }
 
-// NewHardwareController creates a new hardware controller
-func NewHardwareController(accel Accelerometer, gyro Gyroscope, poller InterruptPoller, log *slog.Logger) *HardwareController {
+// NewHardwareController creates a new hardware controller. watcher may be nil
+// if the evdev-based interrupt source is unavailable (e.g. pre-DT-change
+// kernels); the I2C poller alone is sufficient in that case.
+func NewHardwareController(accel Accelerometer, gyro Gyroscope, poller InterruptSource, watcher InterruptSource, log *slog.Logger) *HardwareController {
 	return &HardwareController{
-		accel:  accel,
-		gyro:   gyro,
-		poller: poller,
-		log:    log,
+		accel:   accel,
+		gyro:    gyro,
+		poller:  poller,
+		watcher: watcher,
+		log:     log,
 	}
 }
 
@@ -194,11 +199,14 @@ func (c *HardwareController) EnableInterrupt(ctx context.Context) error {
 		}
 	}
 
+	if c.watcher != nil {
+		c.watcher.Enable()
+	}
 	c.poller.Enable()
 	return nil
 }
 
-// DisableInterrupt disables both interrupt engines and the poller.
+// DisableInterrupt disables both interrupt engines, the poller, and the watcher.
 func (c *HardwareController) DisableInterrupt(ctx context.Context) error {
 	c.log.Info("disabling interrupt")
 
@@ -210,7 +218,10 @@ func (c *HardwareController) DisableInterrupt(ctx context.Context) error {
 		errs = append(errs, err)
 	}
 
-	// Always disable the poller even if hardware disable fails.
+	// Always disable the poller and watcher even if hardware disable fails.
+	if c.watcher != nil {
+		c.watcher.Disable()
+	}
 	c.poller.Disable()
 
 	if len(errs) > 0 {

--- a/internal/bmx/hardware_controller_test.go
+++ b/internal/bmx/hardware_controller_test.go
@@ -146,7 +146,7 @@ func TestHardwareController_EnableInterrupt(t *testing.T) {
 	poller := &mockInterruptPoller{}
 	log := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
 
-	controller := NewHardwareController(accel, gyro, poller, log)
+	controller := NewHardwareController(accel, gyro, poller, nil, log)
 	ctx := context.Background()
 
 	// Use slow-motion mode so EnableSlowNoMotionInterrupt is called.
@@ -175,7 +175,7 @@ func TestHardwareController_DisableInterrupt(t *testing.T) {
 	poller := &mockInterruptPoller{enabled: true}
 	log := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
 
-	controller := NewHardwareController(accel, gyro, poller, log)
+	controller := NewHardwareController(accel, gyro, poller, nil, log)
 
 	ctx := context.Background()
 	if err := controller.DisableInterrupt(ctx); err != nil {
@@ -201,7 +201,7 @@ func TestHardwareController_EnableDisableCycle(t *testing.T) {
 	poller := &mockInterruptPoller{}
 	log := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
 
-	controller := NewHardwareController(accel, gyro, poller, log)
+	controller := NewHardwareController(accel, gyro, poller, nil, log)
 	ctx := context.Background()
 
 	// Use slow-motion mode so EnableSlowNoMotionInterrupt is called.
@@ -249,7 +249,7 @@ func TestHardwareController_SoftReset(t *testing.T) {
 	poller := &mockInterruptPoller{}
 	log := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
 
-	controller := NewHardwareController(accel, gyro, poller, log)
+	controller := NewHardwareController(accel, gyro, poller, nil, log)
 
 	ctx := context.Background()
 	if err := controller.SoftReset(ctx); err != nil {
@@ -286,7 +286,7 @@ func TestHardwareController_EnableInterruptError(t *testing.T) {
 	poller := &mockInterruptPoller{}
 	log := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
 
-	controller := NewHardwareController(accel, gyro, poller, log)
+	controller := NewHardwareController(accel, gyro, poller, nil, log)
 	ctx := context.Background()
 
 	// Use slow-motion mode so EnableSlowNoMotionInterrupt is called (and returns the error).
@@ -311,7 +311,7 @@ func TestHardwareController_DisableInterruptError(t *testing.T) {
 	poller := &mockInterruptPoller{enabled: true}
 	log := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
 
-	controller := NewHardwareController(accel, gyro, poller, log)
+	controller := NewHardwareController(accel, gyro, poller, nil, log)
 
 	ctx := context.Background()
 	err := controller.DisableInterrupt(ctx)

--- a/internal/hardware/interrupt_poller.go
+++ b/internal/hardware/interrupt_poller.go
@@ -11,20 +11,26 @@ import (
 	"alarm-service/internal/redis"
 )
 
-// InterruptPoller monitors for motion interrupts and publishes to Redis
+// InterruptPoller monitors for motion interrupts and publishes to Redis.
+// When the evdev InterruptWatcher is running it is the fast path; this poller
+// then acts as a watchdog at a much slower rate, catching anything the evdev
+// path might have dropped and keeping the BMX055 latch clear.
 type InterruptPoller struct {
 	accel     *bmx.Accelerometer
 	gyro      *bmx.Gyroscope
 	publisher *redis.Publisher
 	log       *slog.Logger
+	interval  time.Duration
 	enabled   atomic.Bool
 }
 
-// NewInterruptPoller creates a new InterruptPoller
+// NewInterruptPoller creates a new InterruptPoller. interval sets how often
+// the status register is read while the poller is enabled.
 func NewInterruptPoller(
 	accel *bmx.Accelerometer,
 	gyro *bmx.Gyroscope,
 	publisher *redis.Publisher,
+	interval time.Duration,
 	log *slog.Logger,
 ) *InterruptPoller {
 	return &InterruptPoller{
@@ -32,6 +38,7 @@ func NewInterruptPoller(
 		gyro:      gyro,
 		publisher: publisher,
 		log:       log,
+		interval:  interval,
 	}
 }
 
@@ -49,9 +56,9 @@ func (p *InterruptPoller) Disable() {
 
 // Run starts the interrupt polling loop
 func (p *InterruptPoller) Run(ctx context.Context) {
-	p.log.Info("starting interrupt poller")
+	p.log.Info("starting interrupt poller", "interval", p.interval)
 
-	ticker := time.NewTicker(100 * time.Millisecond)
+	ticker := time.NewTicker(p.interval)
 	defer ticker.Stop()
 
 	for {

--- a/internal/hardware/interrupt_watcher.go
+++ b/internal/hardware/interrupt_watcher.go
@@ -1,0 +1,152 @@
+package hardware
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"sync/atomic"
+	"time"
+
+	"alarm-service/internal/hardware/bmx"
+	"alarm-service/internal/redis"
+)
+
+const (
+	// evdev event types and sizes for a 32-bit ARM target.
+	evdevTypeKey   = 0x01
+	evdevEventSize = 16
+)
+
+// InterruptWatcher reads the gpio-keys input event device for a specific
+// keycode and publishes motion events the moment the BMX055 INT1 line rises,
+// clearing the latched interrupt on the chip side. It runs alongside the
+// I2C-based InterruptPoller: the watcher is the primary zero-latency path,
+// the poller is a slow-tick watchdog that covers any missed edges.
+type InterruptWatcher struct {
+	devicePath string
+	keycode    uint16
+	accel      *bmx.Accelerometer
+	publisher  *redis.Publisher
+	log        *slog.Logger
+
+	file    *os.File
+	enabled atomic.Bool
+}
+
+// NewInterruptWatcher returns a watcher that opens devicePath and filters
+// for key-press events matching keycode.
+func NewInterruptWatcher(
+	devicePath string,
+	keycode uint16,
+	accel *bmx.Accelerometer,
+	publisher *redis.Publisher,
+	log *slog.Logger,
+) *InterruptWatcher {
+	return &InterruptWatcher{
+		devicePath: devicePath,
+		keycode:    keycode,
+		accel:      accel,
+		publisher:  publisher,
+		log:        log.With("evdev", devicePath, "keycode", keycode),
+	}
+}
+
+// Open opens the input device. Returns an error if the device is missing so
+// the caller can decide to fall back to polling-only mode.
+func (w *InterruptWatcher) Open() error {
+	f, err := os.OpenFile(w.devicePath, os.O_RDONLY, 0)
+	if err != nil {
+		return fmt.Errorf("open %s: %w", w.devicePath, err)
+	}
+	w.file = f
+	w.log.Info("interrupt watcher opened")
+	return nil
+}
+
+// Close releases the input device and unblocks any outstanding read by
+// closing the fd.
+func (w *InterruptWatcher) Close() {
+	if w.file != nil {
+		w.file.Close()
+		w.file = nil
+		w.log.Info("interrupt watcher closed")
+	}
+}
+
+// Enable starts publishing motion events and clearing the latch when the
+// configured keycode is pressed. Events that arrive while disabled are
+// dropped — the FSM is typically not in an armed state then and the
+// BMX055 should not be driving INT1 at all.
+func (w *InterruptWatcher) Enable() {
+	w.enabled.Store(true)
+	w.log.Info("interrupt watcher enabled")
+}
+
+// Disable stops publishing motion events.
+func (w *InterruptWatcher) Disable() {
+	w.enabled.Store(false)
+	w.log.Info("interrupt watcher disabled")
+}
+
+// Run reads input events until ctx is cancelled or the device closes.
+// Blocking read on the input fd is unblocked by Close().
+func (w *InterruptWatcher) Run(ctx context.Context) {
+	w.log.Info("starting interrupt watcher")
+	defer w.Close()
+
+	buf := make([]byte, evdevEventSize)
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+		n, err := w.file.Read(buf)
+		if err != nil {
+			if errors.Is(err, io.EOF) || errors.Is(err, os.ErrClosed) || ctx.Err() != nil {
+				return
+			}
+			w.log.Error("input read failed", "error", err)
+			time.Sleep(100 * time.Millisecond)
+			continue
+		}
+		if n != evdevEventSize {
+			w.log.Warn("short evdev read", "bytes", n)
+			continue
+		}
+
+		typ := binary.LittleEndian.Uint16(buf[8:10])
+		code := binary.LittleEndian.Uint16(buf[10:12])
+		val := int32(binary.LittleEndian.Uint32(buf[12:16]))
+
+		if typ != evdevTypeKey || code != w.keycode || val != 1 {
+			continue
+		}
+
+		if !w.enabled.Load() {
+			w.log.Debug("dropping interrupt edge (watcher disabled)")
+			continue
+		}
+
+		w.handleEdge()
+	}
+}
+
+// handleEdge publishes the motion event and clears the BMX055 latch.
+// Publish first so the FSM sees the event even if the I2C clear fails
+// (the poller's next tick will try again).
+func (w *InterruptWatcher) handleEdge() {
+	ts := time.Now().UnixMilli()
+	w.log.Info("motion interrupt edge", "timestamp", ts)
+
+	payload := fmt.Sprintf("%d", ts)
+	if err := w.publisher.PublishInterrupt(payload); err != nil {
+		w.log.Error("failed to publish interrupt", "error", err)
+	}
+
+	if err := w.accel.ClearLatchedInterrupt(); err != nil {
+		w.log.Warn("failed to clear latched interrupt", "error", err)
+	}
+}


### PR DESCRIPTION
Depends on librescoot/meta-librescoot#41 which adds the gpio-keys entry for BMX055 INT1 (keycode 0x2b).

## What changes

`internal/hardware/interrupt_watcher.go` is new. It opens `/dev/input/by-path/platform-gpio-keys-event`, filters for key-press events on the configured keycode, publishes to `bmx:interrupt`, and clears the BMX055 latch. Gated with `Enable`/`Disable` in lockstep with the existing poller.

`HardwareController` now owns both the poller and the watcher behind a shared `InterruptSource` interface. `EnableInterrupt`/`DisableInterrupt` fire both. The watcher is optional: if the evdev open fails (old DT, or `--evdev-device=""`), the controller runs poller-only and logs a fallback warning.

The poller tick is now configurable and defaults to 1s. With the watcher active that's a watchdog rate. With the watcher disabled the poller falls back to 100ms semantics if you want it that way (just pass `--poller-interval-ms=100`).

No FSM changes. The existing `bmx:interrupt` subscriber already handles events correctly regardless of which path published them.

## New CLI flags

```
--evdev-device        /dev/input/by-path/platform-gpio-keys-event
--evdev-keycode       0x2b
--poller-interval-ms  1000
```

Empty `--evdev-device` disables the watcher and keeps the poller-only behaviour.

## Verified on target

Service starts clean with the new DTB on deep-blue:

```
msg="interrupt watcher opened" evdev=/dev/input/by-path/platform-gpio-keys-event keycode=43
msg="starting interrupt poller" interval=1s
msg="starting interrupt watcher" evdev=/dev/input/by-path/platform-gpio-keys-event keycode=43
msg="interrupt watcher enabled" ...
msg="interrupt monitoring enabled"
```

Fallback path also works: if the DT change hasn't landed and alarm-service starts with the default `--evdev-device`, the evdev open currently succeeds (the device is there) but no events fire (nothing emits keycode 0x2b), so it's inert until the DT is in place. Explicit `--evdev-device=""` disables the watcher entirely.

## Follow-up

Phase C will register `gpio-keys` as a wake source in pm-service so the MDB can actually idle deeper between motion events. Separate bean.

Closes librescoot-4s0p.