### PR TITLE
feat(alarm): input-based tamper triggers + configurable motion sensitivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Each source can be disabled independently via its `alarm.trigger.*` setting. Def
 
 #### Throttle is not a supported trigger source
 
-The thumb throttle is a Hall sensor wired to the Bosch/Votol ECU, not to the MDB. Its state is only visible as a CAN-bus payload from the ECU. In Standby the ECU's 12V rail is cut — CAN goes silent, no throttle data flows. Exposing throttle to the alarm service would require keeping the ECU powered while the scooter is locked, which defeats Standby's power budget. Kickstand, brakes, handlebar lock, and handlebar position cover the "deliberate physical input" use case from [librescoot issue #26](https://github.com/librescoot/librescoot/issues/26) without that cost.
+The thumb throttle is a Hall sensor wired to the Bosch/Votol ECU, not to the MDB. Its state is only visible as a CAN-bus payload from the ECU. In Standby the ECU's 12V rail is cut, CAN goes silent, and no throttle data flows. Exposing throttle to the alarm service would require keeping the ECU powered while the scooter is locked, which defeats Standby's power budget. Kickstand, brakes, handlebar lock, and handlebar position cover the "deliberate physical input" use case from [librescoot issue #26](https://github.com/librescoot/librescoot/issues/26) without that cost.
 
 ### Subscribed Channels
 

--- a/README.md
+++ b/README.md
@@ -68,12 +68,38 @@ Flags:
 
 - `HGET settings alarm.enabled` - Alarm enabled (true/false)
 - `HGET settings alarm.honk` - Horn enabled during alarm (true/false)
+- `HGET settings alarm.duration` - Alarm duration in seconds
+- `HGET settings alarm.hairtrigger` - Short honk on first motion (true/false)
+- `HGET settings alarm.hairtrigger-duration` - Hair-trigger honk duration in seconds
+- `HGET settings alarm.l1-cooldown` - Level 1 cooldown duration in seconds
+- `HGET settings alarm.seatbox-trigger` - Unauthorized seatbox opening triggers alarm (true/false)
+- `HGET settings alarm.sensitivity` - Motion sensitivity in armed state: `low`, `medium`, `high`
+- `HGET settings alarm.trigger.motion` - BMX055 motion triggers alarm (true/false, default true)
+- `HGET settings alarm.trigger.buttons` - Brake/horn/seatbox button presses trigger alarm (true/false, default true)
+- `HGET settings alarm.trigger.handlebar` - Handlebar lock sensor / position triggers alarm (true/false, default true)
+
+### Trigger Sources
+
+Each source can be disabled independently via its `alarm.trigger.*` setting. Defaults are all-on. For the Berlin-vibration "inputs-only" mode, set `alarm.trigger.motion=false` and leave the others on.
+
+| Source | Signal | Needs vehicle-service in Standby |
+|---|---|---|
+| Motion | `bmx:interrupt` channel (BMX055 accelerometer) | — |
+| Buttons | `buttons` channel (brake:{left,right}:on, seatbox:on, horn:on) | Already live in Standby |
+| Handlebar lock | `vehicle.handlebar:lock-sensor` = unlocked | Already live in Standby |
+| Handlebar position | `vehicle.handlebar:position` = off-place | Already live in Standby |
+| Seatbox lock | `vehicle.seatbox:lock` = open + no authorized-open event | Already live in Standby |
+
+#### Throttle is not a supported trigger source
+
+The thumb throttle is a Hall sensor wired to the Bosch/Votol ECU, not to the MDB. Its state is only visible as a CAN-bus payload from the ECU. In Standby the ECU's 12V rail is cut — CAN goes silent, no throttle data flows. Exposing throttle to the alarm service would require keeping the ECU powered while the scooter is locked, which defeats Standby's power budget. Kickstand, brakes, handlebar lock, and handlebar position cover the "deliberate physical input" use case from [librescoot issue #26](https://github.com/librescoot/librescoot/issues/26) without that cost.
 
 ### Subscribed Channels
 
-- `vehicle` - Vehicle state changes (payload: "state")
-- `settings` - Settings changes (payload: "alarm.enabled" or "alarm.honk")
+- `vehicle` - Vehicle state + seatbox lock + handlebar lock/position updates
+- `settings` - Settings changes (alarm.*)
 - `bmx:interrupt` - Motion detection from integrated BMX055 hardware
+- `buttons` - Physical button edges from vehicle-service (brake/seatbox/horn/blinker)
 
 ### Published Status
 
@@ -128,12 +154,15 @@ redis-cli LPUSH scooter:alarm enable
 
 ## State-Specific Behavior
 
-| State | Wake Lock | Sensitivity | INT Pin |
-|-------|-----------|-------------|---------|
-| armed | No | MEDIUM | NONE |
-| delay_armed | Yes | LOW | INT2 |
-| trigger_level_1 | Yes | MEDIUM | NONE |
-| trigger_level_2 | Yes | HIGH | NONE |
+| State | Wake Lock | Sensor config | INT Pin |
+|-------|-----------|---------------|---------|
+| armed | No | any-motion, bandwidth 31.25 Hz, threshold per `alarm.sensitivity` (low=0x08, medium=0x04, high=0x02) | BOTH |
+| delay_armed | Yes | slow-motion idle (threshold 0x14) | INT2 |
+| trigger_level_1 | Yes | slow-motion, bandwidth 15.63 Hz, threshold 0x08 | BOTH |
+| trigger_level_2 | Yes | slow-motion idle | — |
+| waiting_movement | Yes | slow-motion, bandwidth 7.81 Hz, threshold 0x06 (at t=47s) | NONE |
+
+`alarm.sensitivity` tunes the armed-state threshold only; escalation stages (L1 confirm, L2 re-trigger) stay fixed.
 
 ## License
 

--- a/internal/fsm/events.go
+++ b/internal/fsm/events.go
@@ -102,10 +102,10 @@ func (s TriggerSource) String() string {
 }
 
 // InputTriggerEvent signals tamper detected via a discrete input other than
-// the BMX accelerometer — brake levers, handlebar buttons, handlebar lock
-// sensor, handlebar position sensor. Treated by the FSM like BMXInterruptEvent
-// for escalation purposes. Emitted by the subscriber only when the matching
-// per-source flag is enabled.
+// the BMX accelerometer (brake levers, handlebar buttons, handlebar lock
+// sensor, handlebar position sensor). Treated by the FSM like
+// BMXInterruptEvent for escalation purposes. Emitted by the subscriber only
+// when the matching per-source flag is enabled.
 type InputTriggerEvent struct {
 	Source TriggerSource
 }

--- a/internal/fsm/events.go
+++ b/internal/fsm/events.go
@@ -67,6 +67,91 @@ type BMXInterruptEvent struct {
 
 func (e BMXInterruptEvent) Type() string { return "bmx_interrupt" }
 
+// TriggerSource identifies which discrete input caused an InputTriggerEvent.
+// Motion and seatbox are kept on their own event types for historical reasons;
+// this covers the additional non-motion sources (buttons, handlebar sensors).
+type TriggerSource int
+
+const (
+	TriggerSourceUnknown TriggerSource = iota
+	TriggerSourceBrakeLeft
+	TriggerSourceBrakeRight
+	TriggerSourceSeatboxButton
+	TriggerSourceHornButton
+	TriggerSourceHandlebarLock
+	TriggerSourceHandlebarPosition
+)
+
+func (s TriggerSource) String() string {
+	switch s {
+	case TriggerSourceBrakeLeft:
+		return "brake_left"
+	case TriggerSourceBrakeRight:
+		return "brake_right"
+	case TriggerSourceSeatboxButton:
+		return "seatbox_button"
+	case TriggerSourceHornButton:
+		return "horn_button"
+	case TriggerSourceHandlebarLock:
+		return "handlebar_lock"
+	case TriggerSourceHandlebarPosition:
+		return "handlebar_position"
+	default:
+		return "unknown"
+	}
+}
+
+// InputTriggerEvent signals tamper detected via a discrete input other than
+// the BMX accelerometer — brake levers, handlebar buttons, handlebar lock
+// sensor, handlebar position sensor. Treated by the FSM like BMXInterruptEvent
+// for escalation purposes. Emitted by the subscriber only when the matching
+// per-source flag is enabled.
+type InputTriggerEvent struct {
+	Source TriggerSource
+}
+
+func (e InputTriggerEvent) Type() string { return "input_trigger" }
+
+// TriggerSourceCategory groups the per-source enable flags exposed on the
+// settings hash. Motion and seatbox get their own categories; other discrete
+// inputs split into "buttons" and "handlebar" for coarser-grained control.
+type TriggerSourceCategory int
+
+const (
+	TriggerCategoryMotion TriggerSourceCategory = iota
+	TriggerCategoryButtons
+	TriggerCategoryHandlebar
+)
+
+func (c TriggerSourceCategory) String() string {
+	switch c {
+	case TriggerCategoryMotion:
+		return "motion"
+	case TriggerCategoryButtons:
+		return "buttons"
+	case TriggerCategoryHandlebar:
+		return "handlebar"
+	default:
+		return "unknown"
+	}
+}
+
+// TriggerSourceSettingChangedEvent signals that a per-source trigger enable
+// flag was toggled via the settings hash.
+type TriggerSourceSettingChangedEvent struct {
+	Category TriggerSourceCategory
+	Enabled  bool
+}
+
+func (e TriggerSourceSettingChangedEvent) Type() string { return "trigger_source_setting_changed" }
+
+// SensitivityChangedEvent signals that alarm.sensitivity changed.
+type SensitivityChangedEvent struct {
+	Sensitivity Sensitivity
+}
+
+func (e SensitivityChangedEvent) Type() string { return "sensitivity_changed" }
+
 // RuntimeArmEvent forces the FSM to arm without changing alarm.enabled
 type RuntimeArmEvent struct{}
 

--- a/internal/fsm/state_machine.go
+++ b/internal/fsm/state_machine.go
@@ -127,9 +127,9 @@ type StateMachine struct {
 	initWakeL1           bool // L1 triggered from stale BMX latch during startup
 	wakeFromHibernation  bool // woken from hibernation by nRF52 accelerometer
 	sensitivity          Sensitivity
-	motionEnabled        bool // alarm.trigger.motion — false = ignore BMX triggers
-	buttonsEnabled       bool // alarm.trigger.buttons — enables brake/horn/seatbox button triggers
-	handlebarEnabled     bool // alarm.trigger.handlebar — enables handlebar lock/position triggers
+	motionEnabled        bool // alarm.trigger.motion: false means ignore BMX triggers
+	buttonsEnabled       bool // alarm.trigger.buttons: enables brake/horn/seatbox button triggers
+	handlebarEnabled     bool // alarm.trigger.handlebar: enables handlebar lock/position triggers
 }
 
 // SensorConfig mirrors hwbmx.SensorConfig at the FSM layer to avoid an import cycle.
@@ -145,17 +145,17 @@ var (
 	// sensorIdle: low-BW slow-motion used in init/delay/disarmed states (interrupt disabled).
 	sensorIdle = SensorConfig{AnyMotion: false, Bandwidth: 0x08, Threshold: 0x14, Duration: 0x02}
 
-	// sensorArmedLow: any-motion at 31.25 Hz with relaxed threshold — ignores
-	// ground-borne vibration (subways, trams, trucks), still catches deliberate
-	// pushes. threshold 0x08 (~32 mg), 2 samples.
+	// sensorArmedLow: any-motion at 31.25 Hz with relaxed threshold. Ignores
+	// ground-borne vibration (subways, trams, trucks); still catches
+	// deliberate pushes. Threshold 0x08 (~32 mg), 2 samples.
 	sensorArmedLow = SensorConfig{AnyMotion: true, Bandwidth: 0x0A, Threshold: 0x08, Duration: 0x01}
 
-	// sensorArmedMedium (default): any-motion at 31.25 Hz — catches dog bumps
-	// and brief contact (~32 ms). threshold 0x04 (~16 mg), 2 samples.
+	// sensorArmedMedium (default): any-motion at 31.25 Hz. Catches dog bumps
+	// and brief contact (~32 ms). Threshold 0x04 (~16 mg), 2 samples.
 	sensorArmedMedium = SensorConfig{AnyMotion: true, Bandwidth: 0x0A, Threshold: 0x04, Duration: 0x01}
 
-	// sensorArmedHigh: any-motion at 31.25 Hz with tight threshold — paranoid
-	// mode for quiet parking environments. threshold 0x02 (~8 mg), 2 samples.
+	// sensorArmedHigh: any-motion at 31.25 Hz with tight threshold. Paranoid
+	// mode for quiet parking environments. Threshold 0x02 (~8 mg), 2 samples.
 	sensorArmedHigh = SensorConfig{AnyMotion: true, Bandwidth: 0x0A, Threshold: 0x02, Duration: 0x01}
 
 	// sensorLevel1: slow-motion at 15.63 Hz — confirms deliberate push/tilt (~256 ms).
@@ -249,7 +249,8 @@ func New(
 }
 
 // isTamperTrigger reports whether an event should be treated as a tamper
-// trigger — BMX motion or a discrete input. Both feed the same escalation path.
+// trigger (BMX motion or a discrete input). Both feed the same escalation
+// path.
 func isTamperTrigger(e Event) bool {
 	switch e.(type) {
 	case BMXInterruptEvent, InputTriggerEvent:

--- a/internal/fsm/state_machine.go
+++ b/internal/fsm/state_machine.go
@@ -60,6 +60,20 @@ func (s Sensitivity) String() string {
 	}
 }
 
+// ParseSensitivity parses a sensitivity string. Unknown values map to medium.
+func ParseSensitivity(s string) Sensitivity {
+	switch s {
+	case "low":
+		return SensitivityLow
+	case "medium":
+		return SensitivityMedium
+	case "high":
+		return SensitivityHigh
+	default:
+		return SensitivityMedium
+	}
+}
+
 // InterruptPin represents BMX interrupt pin
 type InterruptPin int
 
@@ -112,6 +126,10 @@ type StateMachine struct {
 	seatboxLockClosed    bool
 	initWakeL1           bool // L1 triggered from stale BMX latch during startup
 	wakeFromHibernation  bool // woken from hibernation by nRF52 accelerometer
+	sensitivity          Sensitivity
+	motionEnabled        bool // alarm.trigger.motion — false = ignore BMX triggers
+	buttonsEnabled       bool // alarm.trigger.buttons — enables brake/horn/seatbox button triggers
+	handlebarEnabled     bool // alarm.trigger.handlebar — enables handlebar lock/position triggers
 }
 
 // SensorConfig mirrors hwbmx.SensorConfig at the FSM layer to avoid an import cycle.
@@ -127,8 +145,18 @@ var (
 	// sensorIdle: low-BW slow-motion used in init/delay/disarmed states (interrupt disabled).
 	sensorIdle = SensorConfig{AnyMotion: false, Bandwidth: 0x08, Threshold: 0x14, Duration: 0x02}
 
-	// sensorArmed: any-motion at 31.25 Hz — catches dog bumps and brief contact (~32 ms).
-	sensorArmed = SensorConfig{AnyMotion: true, Bandwidth: 0x0A, Threshold: 0x04, Duration: 0x01}
+	// sensorArmedLow: any-motion at 31.25 Hz with relaxed threshold — ignores
+	// ground-borne vibration (subways, trams, trucks), still catches deliberate
+	// pushes. threshold 0x08 (~32 mg), 2 samples.
+	sensorArmedLow = SensorConfig{AnyMotion: true, Bandwidth: 0x0A, Threshold: 0x08, Duration: 0x01}
+
+	// sensorArmedMedium (default): any-motion at 31.25 Hz — catches dog bumps
+	// and brief contact (~32 ms). threshold 0x04 (~16 mg), 2 samples.
+	sensorArmedMedium = SensorConfig{AnyMotion: true, Bandwidth: 0x0A, Threshold: 0x04, Duration: 0x01}
+
+	// sensorArmedHigh: any-motion at 31.25 Hz with tight threshold — paranoid
+	// mode for quiet parking environments. threshold 0x02 (~8 mg), 2 samples.
+	sensorArmedHigh = SensorConfig{AnyMotion: true, Bandwidth: 0x0A, Threshold: 0x02, Duration: 0x01}
 
 	// sensorLevel1: slow-motion at 15.63 Hz — confirms deliberate push/tilt (~256 ms).
 	sensorLevel1 = SensorConfig{AnyMotion: false, Bandwidth: 0x09, Threshold: 0x08, Duration: 0x03}
@@ -136,6 +164,18 @@ var (
 	// sensorWaiting: slow-motion at 7.81 Hz — conservative re-trigger for L2 (~512 ms).
 	sensorWaiting = SensorConfig{AnyMotion: false, Bandwidth: 0x08, Threshold: 0x06, Duration: 0x03}
 )
+
+// sensorArmedFor returns the armed-state sensor config for a given sensitivity.
+func sensorArmedFor(s Sensitivity) SensorConfig {
+	switch s {
+	case SensitivityLow:
+		return sensorArmedLow
+	case SensitivityHigh:
+		return sensorArmedHigh
+	default:
+		return sensorArmedMedium
+	}
+}
 
 // BMXClient interface for BMX commands
 type BMXClient interface {
@@ -201,7 +241,21 @@ func New(
 		l1CooldownDuration:  5,
 		preSeatboxState:     StateInit,
 		seatboxLockClosed:   true,
+		sensitivity:         SensitivityMedium,
+		motionEnabled:       true,
+		buttonsEnabled:      true,
+		handlebarEnabled:    true,
 	}
+}
+
+// isTamperTrigger reports whether an event should be treated as a tamper
+// trigger — BMX motion or a discrete input. Both feed the same escalation path.
+func isTamperTrigger(e Event) bool {
+	switch e.(type) {
+	case BMXInterruptEvent, InputTriggerEvent:
+		return true
+	}
+	return false
 }
 
 // Run runs the state machine event loop
@@ -289,6 +343,43 @@ func (sm *StateMachine) handleEvent(ctx context.Context, event Event) {
 		return
 	}
 
+	if e, ok := event.(TriggerSourceSettingChangedEvent); ok {
+		switch e.Category {
+		case TriggerCategoryMotion:
+			sm.motionEnabled = e.Enabled
+		case TriggerCategoryButtons:
+			sm.buttonsEnabled = e.Enabled
+		case TriggerCategoryHandlebar:
+			sm.handlebarEnabled = e.Enabled
+		}
+		sm.log.Info("trigger source setting updated", "category", e.Category.String(), "enabled", e.Enabled)
+		return
+	}
+
+	if e, ok := event.(SensitivityChangedEvent); ok {
+		if sm.sensitivity == e.Sensitivity {
+			return
+		}
+		sm.sensitivity = e.Sensitivity
+		sm.log.Info("sensitivity updated", "sensitivity", e.Sensitivity.String())
+		if sm.state == StateArmed {
+			sm.log.Info("reconfiguring armed sensor for new sensitivity")
+			sm.configureBMX(sm.ctx, InterruptPinBoth, sensorArmedFor(sm.sensitivity))
+			if err := sm.bmxClient.EnableInterrupt(sm.ctx); err != nil {
+				sm.log.Error("failed to re-enable interrupt after sensitivity change", "error", err)
+			}
+		}
+		return
+	}
+
+	// Drop motion triggers if the motion source is disabled. InputTriggerEvent
+	// is already pre-filtered at the subscriber layer, so we only need to
+	// gate BMX here.
+	if _, ok := event.(BMXInterruptEvent); ok && !sm.motionEnabled {
+		sm.log.Debug("dropping BMX interrupt (motion trigger source disabled)")
+		return
+	}
+
 	oldState := sm.state
 	sm.log.Debug("handling event",
 		"event", event.Type(),
@@ -297,13 +388,12 @@ func (sm *StateMachine) handleEvent(ctx context.Context, event Event) {
 	newState := sm.getTransition(event)
 
 	if newState != oldState {
-		// Blink hazards when movement detected during L1 (before L2 activation)
-		if oldState == StateTriggerLevel1 && newState == StateTriggerLevel2 {
-			if _, ok := event.(BMXInterruptEvent); ok {
-				sm.log.Info("movement detected during L1, blinking hazards")
-				if err := sm.alarmController.BlinkHazards(); err != nil {
-					sm.log.Error("failed to blink hazards", "error", err)
-				}
+		// Blink hazards when tampering detected during L1 (before L2 activation).
+		// Either motion or discrete input counts.
+		if oldState == StateTriggerLevel1 && newState == StateTriggerLevel2 && isTamperTrigger(event) {
+			sm.log.Info("tampering detected during L1, blinking hazards", "event", event.Type())
+			if err := sm.alarmController.BlinkHazards(); err != nil {
+				sm.log.Error("failed to blink hazards", "error", err)
 			}
 		}
 

--- a/internal/fsm/state_machine_test.go
+++ b/internal/fsm/state_machine_test.go
@@ -939,3 +939,176 @@ func TestStateMachine_InitToArmedSkipsDelay(t *testing.T) {
 		t.Error("expected interrupt to be enabled in armed state")
 	}
 }
+
+// InputTriggerEvent in StateArmed must escalate to TriggerLevel1Wait, same as
+// a BMXInterruptEvent. Covers 0679 (buttons) and nor4 (handlebar).
+func TestStateMachine_ArmedInputTriggerEscalatesToL1Wait(t *testing.T) {
+	sm, _, _, inh, alarm := createTestStateMachine()
+	ctx := context.Background()
+
+	sm.state = StateArmed
+	sm.alarmEnabled = true
+	sm.vehicleStandby = true
+
+	sm.SendEvent(InputTriggerEvent{Source: TriggerSourceBrakeLeft})
+	sm.handleEvent(ctx, <-sm.events)
+
+	if sm.State() != StateTriggerLevel1Wait {
+		t.Errorf("expected StateTriggerLevel1Wait on input trigger, got %s", sm.State())
+	}
+	if !inh.acquired {
+		t.Error("expected inhibitor acquired in L1 wait")
+	}
+	if alarm.blinkCalled != 1 {
+		t.Errorf("expected hazards to blink once entering L1 wait, got %d", alarm.blinkCalled)
+	}
+}
+
+// InputTriggerEvent in StateTriggerLevel1 must escalate to L2 and blink
+// hazards, just like a BMXInterruptEvent at that point.
+func TestStateMachine_Level1InputTriggerEscalatesToL2(t *testing.T) {
+	sm, _, _, _, alarm := createTestStateMachine()
+	ctx := context.Background()
+
+	sm.state = StateTriggerLevel1
+	sm.alarmDuration = 10
+
+	sm.SendEvent(InputTriggerEvent{Source: TriggerSourceHandlebarLock})
+	sm.handleEvent(ctx, <-sm.events)
+
+	if sm.State() != StateTriggerLevel2 {
+		t.Errorf("expected StateTriggerLevel2, got %s", sm.State())
+	}
+	if !alarm.active {
+		t.Error("expected alarm to be active in level 2")
+	}
+	if alarm.blinkCalled != 1 {
+		t.Errorf("expected hazards to blink once during L1->L2, got %d", alarm.blinkCalled)
+	}
+}
+
+// Motion trigger source disabled — BMX events must be dropped without a state
+// change. Input triggers must still work. Covers u565.
+func TestStateMachine_MotionDisabledDropsBMXKeepsInputs(t *testing.T) {
+	sm, _, _, _, _ := createTestStateMachine()
+	ctx := context.Background()
+
+	sm.state = StateArmed
+	sm.motionEnabled = false
+
+	sm.SendEvent(BMXInterruptEvent{})
+	sm.handleEvent(ctx, <-sm.events)
+	if sm.State() != StateArmed {
+		t.Errorf("expected StateArmed (motion disabled), got %s", sm.State())
+	}
+
+	sm.SendEvent(InputTriggerEvent{Source: TriggerSourceBrakeLeft})
+	sm.handleEvent(ctx, <-sm.events)
+	if sm.State() != StateTriggerLevel1Wait {
+		t.Errorf("expected StateTriggerLevel1Wait on input trigger, got %s", sm.State())
+	}
+}
+
+// TriggerSourceSettingChangedEvent updates the FSM's per-source flag without
+// transitioning, and the flag takes effect on subsequent events.
+func TestStateMachine_TriggerSourceSettingChange(t *testing.T) {
+	sm, _, _, _, _ := createTestStateMachine()
+	ctx := context.Background()
+
+	sm.state = StateArmed
+	if !sm.motionEnabled {
+		t.Fatal("motion should default enabled")
+	}
+
+	sm.SendEvent(TriggerSourceSettingChangedEvent{Category: TriggerCategoryMotion, Enabled: false})
+	sm.handleEvent(ctx, <-sm.events)
+
+	if sm.motionEnabled {
+		t.Error("motion should be disabled after setting change")
+	}
+	if sm.State() != StateArmed {
+		t.Errorf("state should not change on setting update, got %s", sm.State())
+	}
+}
+
+// Sensitivity setting flows into the armed sensor config. Covers 2uyg.
+func TestStateMachine_SensitivityChangeArmedReconfigures(t *testing.T) {
+	sm, bmx, _, _, _ := createTestStateMachine()
+	ctx := context.Background()
+
+	sm.state = StateArmed
+
+	sm.SendEvent(SensitivityChangedEvent{Sensitivity: SensitivityLow})
+	sm.handleEvent(ctx, <-sm.events)
+
+	if sm.sensitivity != SensitivityLow {
+		t.Errorf("expected sensitivity low, got %s", sm.sensitivity.String())
+	}
+	if bmx.lastConfig.Threshold != sensorArmedLow.Threshold {
+		t.Errorf("expected armed sensor reconfigured to low threshold 0x%x, got 0x%x",
+			sensorArmedLow.Threshold, bmx.lastConfig.Threshold)
+	}
+	if !bmx.interruptEnabled {
+		t.Error("expected interrupt re-enabled after sensitivity change in armed")
+	}
+}
+
+// Sensitivity change outside armed must not reconfigure the sensor.
+func TestStateMachine_SensitivityChangeInactiveSkipsReconfig(t *testing.T) {
+	sm, bmx, _, _, _ := createTestStateMachine()
+	ctx := context.Background()
+
+	sm.state = StateDisarmed
+	bmx.lastConfig = SensorConfig{} // reset spy
+
+	sm.SendEvent(SensitivityChangedEvent{Sensitivity: SensitivityHigh})
+	sm.handleEvent(ctx, <-sm.events)
+
+	if sm.sensitivity != SensitivityHigh {
+		t.Errorf("expected sensitivity high, got %s", sm.sensitivity.String())
+	}
+	if bmx.lastConfig.Threshold != 0 {
+		t.Error("expected no reconfigure outside armed state")
+	}
+}
+
+// Entering Armed with a non-default sensitivity must apply the matching
+// sensor config.
+func TestStateMachine_ArmedAppliesSensitivity(t *testing.T) {
+	sm, bmx, _, _, _ := createTestStateMachine()
+	ctx := context.Background()
+
+	sm.state = StateDelayArmed
+	sm.sensitivity = SensitivityHigh
+
+	sm.SendEvent(DelayArmedTimerEvent{})
+	sm.handleEvent(ctx, <-sm.events)
+
+	if sm.State() != StateArmed {
+		t.Fatalf("expected StateArmed, got %s", sm.State())
+	}
+	if bmx.lastConfig.Threshold != sensorArmedHigh.Threshold {
+		t.Errorf("expected high threshold 0x%x, got 0x%x",
+			sensorArmedHigh.Threshold, bmx.lastConfig.Threshold)
+	}
+}
+
+// WaitingMovement must escalate to L2 on InputTrigger the same way it does
+// on BMXInterrupt, and increment the cycle counter.
+func TestStateMachine_WaitingMovementInputTriggerEscalates(t *testing.T) {
+	sm, _, _, _, _ := createTestStateMachine()
+	ctx := context.Background()
+
+	sm.state = StateWaitingMovement
+	sm.level2Cycles = 1
+
+	sm.SendEvent(InputTriggerEvent{Source: TriggerSourceHornButton})
+	sm.handleEvent(ctx, <-sm.events)
+
+	if sm.State() != StateTriggerLevel2 {
+		t.Errorf("expected StateTriggerLevel2, got %s", sm.State())
+	}
+	if sm.level2Cycles != 2 {
+		t.Errorf("expected level2Cycles 2, got %d", sm.level2Cycles)
+	}
+}

--- a/internal/fsm/states.go
+++ b/internal/fsm/states.go
@@ -80,7 +80,7 @@ func (sm *StateMachine) onEnterArmed(ctx context.Context) {
 
 	sm.inhibitor.Release()
 
-	sm.configureBMX(ctx, InterruptPinBoth, sensorArmed)
+	sm.configureBMX(ctx, InterruptPinBoth, sensorArmedFor(sm.sensitivity))
 
 	if err := sm.bmxClient.EnableInterrupt(ctx); err != nil {
 		sm.log.Error("failed to enable interrupt", "error", err)

--- a/internal/fsm/transitions.go
+++ b/internal/fsm/transitions.go
@@ -98,6 +98,9 @@ func (sm *StateMachine) getTransition(event Event) State {
 			}
 			return StateTriggerLevel1Wait
 		}
+		if _, ok := event.(InputTriggerEvent); ok {
+			return StateTriggerLevel1Wait
+		}
 		if e, ok := event.(VehicleStateChangedEvent); ok && shouldDisarmForVehicleState(e.State) {
 			sm.vehicleStandby = false
 			return StateDisarmed
@@ -150,6 +153,9 @@ func (sm *StateMachine) getTransition(event Event) State {
 		if _, ok := event.(BMXInterruptEvent); ok {
 			return StateTriggerLevel2
 		}
+		if _, ok := event.(InputTriggerEvent); ok {
+			return StateTriggerLevel2
+		}
 		if e, ok := event.(VehicleStateChangedEvent); ok && shouldDisarmForVehicleState(e.State) {
 			sm.vehicleStandby = false
 			return StateDisarmed
@@ -185,7 +191,7 @@ func (sm *StateMachine) getTransition(event Event) State {
 		if _, ok := event.(Level2CheckTimerEvent); ok {
 			return StateDelayArmed
 		}
-		if _, ok := event.(BMXInterruptEvent); ok {
+		if isTamperTrigger(event) {
 			sm.level2Cycles++
 			if sm.level2Cycles >= 4 {
 				return StateDisarmed

--- a/internal/redis/subscribers.go
+++ b/internal/redis/subscribers.go
@@ -11,6 +11,13 @@ import (
 	ipc "github.com/librescoot/redis-ipc"
 )
 
+// eventSink is the subset of fsm.StateMachine the subscriber needs. Extracted
+// so unit tests can verify event dispatch without constructing a full FSM.
+type eventSink interface {
+	SendEvent(fsm.Event)
+	State() fsm.State
+}
+
 // Subscriber handles subscribing to Redis channels using HashWatcher
 type Subscriber struct {
 	vehicleWatcher          *ipc.HashWatcher
@@ -19,17 +26,25 @@ type Subscriber struct {
 	buttonsWatcher          *ipc.Subscription[string]
 	ipc                     *ipc.Client
 	log                     *slog.Logger
-	sm                      *fsm.StateMachine
+	sm                      eventSink
 	seatboxTriggerEnabled   bool
 	authorizedSeatboxPending bool
 
 	// Per-source trigger enable flags. Mirror the FSM's own copy so the
 	// subscriber can drop events at the source without waking the FSM, and
-	// notify the FSM for its own bookkeeping on change. Default true — users
+	// notify the FSM for its own bookkeeping on change. Default true; users
 	// opt *out* of a source to get the "inputs-only" or "motion-only" preset.
 	flagMu           sync.RWMutex
 	buttonsEnabled   bool
 	handlebarEnabled bool
+
+	// Previous values for hash fields that represent tamper state. Used to
+	// distinguish genuine safe->unsafe transitions from StartWithSync's
+	// initial-value delivery. Many scooters park with the handlebar lock
+	// never engaged, so "unlocked" is a legitimate resting value we must
+	// not treat as a trigger on service startup.
+	handlebarLockLast string
+	handlebarPosLast  string
 }
 
 // NewSubscriber creates a new Subscriber with HashWatcher instances
@@ -104,37 +119,58 @@ func (s *Subscriber) setupVehicleWatcher() {
 		return nil
 	})
 
-	// Handlebar lock sensor — "unlocked" while armed means someone pulled the
-	// lock bolt without authorization.
-	s.vehicleWatcher.OnField("handlebar:lock-sensor", func(lockState string) error {
-		s.log.Debug("handlebar lock sensor changed", "state", lockState)
-		if lockState != "unlocked" {
-			return nil
-		}
-		if !s.getHandlebarEnabled() {
-			s.log.Debug("handlebar unlocked but handlebar trigger disabled")
-			return nil
-		}
-		s.log.Info("handlebar unlocked — sending input trigger")
-		s.sm.SendEvent(fsm.InputTriggerEvent{Source: fsm.TriggerSourceHandlebarLock})
-		return nil
-	})
+	// Handlebar lock sensor. See handleHandlebarLockField for semantics.
+	s.vehicleWatcher.OnField("handlebar:lock-sensor", s.handleHandlebarLockField)
 
-	// Handlebar position sensor — "off-place" while armed means the bars were
-	// moved away from their locked-straight position.
-	s.vehicleWatcher.OnField("handlebar:position", func(pos string) error {
-		s.log.Debug("handlebar position changed", "position", pos)
-		if pos != "off-place" {
-			return nil
-		}
-		if !s.getHandlebarEnabled() {
-			s.log.Debug("handlebar off-place but handlebar trigger disabled")
-			return nil
-		}
-		s.log.Info("handlebar off-place — sending input trigger")
-		s.sm.SendEvent(fsm.InputTriggerEvent{Source: fsm.TriggerSourceHandlebarPosition})
+	// Handlebar position sensor. See handleHandlebarPositionField for semantics.
+	s.vehicleWatcher.OnField("handlebar:position", s.handleHandlebarPositionField)
+}
+
+// handleHandlebarLockField emits an InputTriggerEvent only on a genuine
+// safe->unsafe transition observed after the initial sync. Scooters routinely
+// park with the handlebar lock never engaged, so "unlocked" is often the
+// resting value. Triggering on StartWithSync's initial delivery would fire
+// the alarm on every service restart of an already-armed scooter.
+func (s *Subscriber) handleHandlebarLockField(lockState string) error {
+	prev := s.handlebarLockLast
+	s.handlebarLockLast = lockState
+	if prev == "" {
+		s.log.Debug("handlebar lock baseline captured", "state", lockState)
 		return nil
-	})
+	}
+	if lockState != "unlocked" || prev == "unlocked" {
+		return nil
+	}
+	if !s.getHandlebarEnabled() {
+		s.log.Debug("handlebar unlocked transition ignored (handlebar trigger disabled)")
+		return nil
+	}
+	s.log.Info("handlebar lock transition to unlocked, sending input trigger", "prev", prev)
+	s.sm.SendEvent(fsm.InputTriggerEvent{Source: fsm.TriggerSourceHandlebarLock})
+	return nil
+}
+
+// handleHandlebarPositionField is the position-sensor counterpart. Same
+// rationale: if the rider parked without turning the bars, "off-place" is
+// the resting value and must not trigger on startup. Only on-place to
+// off-place transitions count.
+func (s *Subscriber) handleHandlebarPositionField(pos string) error {
+	prev := s.handlebarPosLast
+	s.handlebarPosLast = pos
+	if prev == "" {
+		s.log.Debug("handlebar position baseline captured", "position", pos)
+		return nil
+	}
+	if pos != "off-place" || prev == "off-place" {
+		return nil
+	}
+	if !s.getHandlebarEnabled() {
+		s.log.Debug("handlebar off-place transition ignored (handlebar trigger disabled)")
+		return nil
+	}
+	s.log.Info("handlebar position transition to off-place, sending input trigger", "prev", prev)
+	s.sm.SendEvent(fsm.InputTriggerEvent{Source: fsm.TriggerSourceHandlebarPosition})
+	return nil
 }
 
 // parseBoolSetting accepts the common Redis-flavored truthy strings.
@@ -320,15 +356,15 @@ func (s *Subscriber) handleButtonEvent(payload string) error {
 		s.log.Debug("button press ignored (buttons trigger disabled)", "source", source.String())
 		return nil
 	}
-	s.log.Info("button press — sending input trigger", "source", source.String())
+	s.log.Info("button press, sending input trigger", "source", source.String())
 	s.sm.SendEvent(fsm.InputTriggerEvent{Source: source})
 	return nil
 }
 
 // parseButtonPayload recognizes the subset of `buttons` channel payloads we
-// want to act on as tamper triggers. Blinker and throttle are ignored here —
-// blinkers because they are ambient navigation signals, throttle because it
-// is not exposed while the ECU is off.
+// want to act on as tamper triggers. Blinker and throttle are ignored:
+// blinkers are ambient navigation signals, and throttle is not exposed
+// while the ECU is off.
 func parseButtonPayload(payload string) (fsm.TriggerSource, string, bool) {
 	parts := strings.Split(payload, ":")
 	switch len(parts) {

--- a/internal/redis/subscribers.go
+++ b/internal/redis/subscribers.go
@@ -3,6 +3,8 @@ package redis
 import (
 	"fmt"
 	"log/slog"
+	"strings"
+	"sync"
 
 	"alarm-service/internal/fsm"
 
@@ -14,11 +16,20 @@ type Subscriber struct {
 	vehicleWatcher          *ipc.HashWatcher
 	settingsWatcher         *ipc.HashWatcher
 	bmxWatcher              *ipc.Subscription[string]
+	buttonsWatcher          *ipc.Subscription[string]
 	ipc                     *ipc.Client
 	log                     *slog.Logger
 	sm                      *fsm.StateMachine
 	seatboxTriggerEnabled   bool
 	authorizedSeatboxPending bool
+
+	// Per-source trigger enable flags. Mirror the FSM's own copy so the
+	// subscriber can drop events at the source without waking the FSM, and
+	// notify the FSM for its own bookkeeping on change. Default true — users
+	// opt *out* of a source to get the "inputs-only" or "motion-only" preset.
+	flagMu           sync.RWMutex
+	buttonsEnabled   bool
+	handlebarEnabled bool
 }
 
 // NewSubscriber creates a new Subscriber with HashWatcher instances
@@ -30,12 +41,26 @@ func NewSubscriber(client *Client, sm *fsm.StateMachine, log *slog.Logger) *Subs
 		log:                   log,
 		sm:                    sm,
 		seatboxTriggerEnabled: true, // default: seatbox opening can trigger alarm
+		buttonsEnabled:        true, // default: brake/horn/seatbox buttons can trigger alarm
+		handlebarEnabled:      true, // default: handlebar lock/position can trigger alarm
 	}
 
 	s.setupVehicleWatcher()
 	s.setupSettingsWatcher()
 
 	return s
+}
+
+func (s *Subscriber) getButtonsEnabled() bool {
+	s.flagMu.RLock()
+	defer s.flagMu.RUnlock()
+	return s.buttonsEnabled
+}
+
+func (s *Subscriber) getHandlebarEnabled() bool {
+	s.flagMu.RLock()
+	defer s.flagMu.RUnlock()
+	return s.handlebarEnabled
 }
 
 // setupVehicleWatcher registers handlers for vehicle state changes
@@ -78,6 +103,47 @@ func (s *Subscriber) setupVehicleWatcher() {
 		}
 		return nil
 	})
+
+	// Handlebar lock sensor — "unlocked" while armed means someone pulled the
+	// lock bolt without authorization.
+	s.vehicleWatcher.OnField("handlebar:lock-sensor", func(lockState string) error {
+		s.log.Debug("handlebar lock sensor changed", "state", lockState)
+		if lockState != "unlocked" {
+			return nil
+		}
+		if !s.getHandlebarEnabled() {
+			s.log.Debug("handlebar unlocked but handlebar trigger disabled")
+			return nil
+		}
+		s.log.Info("handlebar unlocked — sending input trigger")
+		s.sm.SendEvent(fsm.InputTriggerEvent{Source: fsm.TriggerSourceHandlebarLock})
+		return nil
+	})
+
+	// Handlebar position sensor — "off-place" while armed means the bars were
+	// moved away from their locked-straight position.
+	s.vehicleWatcher.OnField("handlebar:position", func(pos string) error {
+		s.log.Debug("handlebar position changed", "position", pos)
+		if pos != "off-place" {
+			return nil
+		}
+		if !s.getHandlebarEnabled() {
+			s.log.Debug("handlebar off-place but handlebar trigger disabled")
+			return nil
+		}
+		s.log.Info("handlebar off-place — sending input trigger")
+		s.sm.SendEvent(fsm.InputTriggerEvent{Source: fsm.TriggerSourceHandlebarPosition})
+		return nil
+	})
+}
+
+// parseBoolSetting accepts the common Redis-flavored truthy strings.
+func parseBoolSetting(v string) bool {
+	switch strings.ToLower(strings.TrimSpace(v)) {
+	case "true", "1", "yes", "on":
+		return true
+	}
+	return false
 }
 
 // setupSettingsWatcher registers handlers for alarm settings changes
@@ -152,6 +218,49 @@ func (s *Subscriber) setupSettingsWatcher() {
 		s.sm.SendEvent(fsm.L1CooldownDurationChangedEvent{Duration: duration})
 		return nil
 	})
+
+	s.settingsWatcher.OnField("alarm.trigger.motion", func(v string) error {
+		enabled := parseBoolSetting(v)
+		s.log.Info("trigger.motion setting changed", "enabled", enabled)
+		s.sm.SendEvent(fsm.TriggerSourceSettingChangedEvent{
+			Category: fsm.TriggerCategoryMotion,
+			Enabled:  enabled,
+		})
+		return nil
+	})
+
+	s.settingsWatcher.OnField("alarm.trigger.buttons", func(v string) error {
+		enabled := parseBoolSetting(v)
+		s.log.Info("trigger.buttons setting changed", "enabled", enabled)
+		s.flagMu.Lock()
+		s.buttonsEnabled = enabled
+		s.flagMu.Unlock()
+		s.sm.SendEvent(fsm.TriggerSourceSettingChangedEvent{
+			Category: fsm.TriggerCategoryButtons,
+			Enabled:  enabled,
+		})
+		return nil
+	})
+
+	s.settingsWatcher.OnField("alarm.trigger.handlebar", func(v string) error {
+		enabled := parseBoolSetting(v)
+		s.log.Info("trigger.handlebar setting changed", "enabled", enabled)
+		s.flagMu.Lock()
+		s.handlebarEnabled = enabled
+		s.flagMu.Unlock()
+		s.sm.SendEvent(fsm.TriggerSourceSettingChangedEvent{
+			Category: fsm.TriggerCategoryHandlebar,
+			Enabled:  enabled,
+		})
+		return nil
+	})
+
+	s.settingsWatcher.OnField("alarm.sensitivity", func(v string) error {
+		sensitivity := fsm.ParseSensitivity(strings.TrimSpace(v))
+		s.log.Info("sensitivity setting changed", "sensitivity", sensitivity.String())
+		s.sm.SendEvent(fsm.SensitivityChangedEvent{Sensitivity: sensitivity})
+		return nil
+	})
 }
 
 // Start starts all watchers with initial state sync and signals the FSM to
@@ -185,7 +294,66 @@ func (s *Subscriber) Start() error {
 		return fmt.Errorf("failed to subscribe to bmx:interrupt: %w", err)
 	}
 
+	s.log.Info("starting buttons subscription")
+	s.buttonsWatcher, err = ipc.Subscribe(s.ipc, "buttons", s.handleButtonEvent)
+	if err != nil {
+		return fmt.Errorf("failed to subscribe to buttons: %w", err)
+	}
+
 	return nil
+}
+
+// handleButtonEvent routes a `buttons` PUBSUB payload to the FSM as an
+// InputTriggerEvent when the source is armed for triggering and the edge is
+// "on". Payload format mirrors vehicle-service's PublishButtonEvent output,
+// e.g. "brake:left:on", "brake:right:off", "seatbox:on", "horn:on".
+func (s *Subscriber) handleButtonEvent(payload string) error {
+	source, edge, ok := parseButtonPayload(payload)
+	if !ok {
+		s.log.Debug("unrecognized button payload", "payload", payload)
+		return nil
+	}
+	if edge != "on" {
+		return nil
+	}
+	if !s.getButtonsEnabled() {
+		s.log.Debug("button press ignored (buttons trigger disabled)", "source", source.String())
+		return nil
+	}
+	s.log.Info("button press — sending input trigger", "source", source.String())
+	s.sm.SendEvent(fsm.InputTriggerEvent{Source: source})
+	return nil
+}
+
+// parseButtonPayload recognizes the subset of `buttons` channel payloads we
+// want to act on as tamper triggers. Blinker and throttle are ignored here —
+// blinkers because they are ambient navigation signals, throttle because it
+// is not exposed while the ECU is off.
+func parseButtonPayload(payload string) (fsm.TriggerSource, string, bool) {
+	parts := strings.Split(payload, ":")
+	switch len(parts) {
+	case 2:
+		// "seatbox:on", "horn:on"
+		edge := parts[1]
+		switch parts[0] {
+		case "seatbox":
+			return fsm.TriggerSourceSeatboxButton, edge, true
+		case "horn":
+			return fsm.TriggerSourceHornButton, edge, true
+		}
+	case 3:
+		// "brake:left:on", "brake:right:on"
+		if parts[0] == "brake" {
+			edge := parts[2]
+			switch parts[1] {
+			case "left":
+				return fsm.TriggerSourceBrakeLeft, edge, true
+			case "right":
+				return fsm.TriggerSourceBrakeRight, edge, true
+			}
+		}
+	}
+	return fsm.TriggerSourceUnknown, "", false
 }
 
 // Stop stops all watchers
@@ -194,5 +362,8 @@ func (s *Subscriber) Stop() {
 	s.settingsWatcher.Stop()
 	if s.bmxWatcher != nil {
 		s.bmxWatcher.Unsubscribe()
+	}
+	if s.buttonsWatcher != nil {
+		s.buttonsWatcher.Unsubscribe()
 	}
 }

--- a/internal/redis/subscribers_test.go
+++ b/internal/redis/subscribers_test.go
@@ -1,0 +1,72 @@
+package redis
+
+import (
+	"testing"
+
+	"alarm-service/internal/fsm"
+)
+
+// parseButtonPayload must accept the payloads vehicle-service publishes on the
+// `buttons` channel and map them to the right TriggerSource. Unknown payloads
+// (blinkers, garbage, etc.) return !ok and must be ignored.
+func TestParseButtonPayload(t *testing.T) {
+	cases := []struct {
+		payload    string
+		wantSource fsm.TriggerSource
+		wantEdge   string
+		wantOK     bool
+	}{
+		{"seatbox:on", fsm.TriggerSourceSeatboxButton, "on", true},
+		{"seatbox:off", fsm.TriggerSourceSeatboxButton, "off", true},
+		{"horn:on", fsm.TriggerSourceHornButton, "on", true},
+		{"horn:off", fsm.TriggerSourceHornButton, "off", true},
+		{"brake:left:on", fsm.TriggerSourceBrakeLeft, "on", true},
+		{"brake:left:off", fsm.TriggerSourceBrakeLeft, "off", true},
+		{"brake:right:on", fsm.TriggerSourceBrakeRight, "on", true},
+		{"brake:right:off", fsm.TriggerSourceBrakeRight, "off", true},
+
+		// Blinkers are published on the same channel but are not tamper
+		// triggers — the subscriber must ignore them.
+		{"blinker:left:on", fsm.TriggerSourceUnknown, "", false},
+		{"blinker:right:off", fsm.TriggerSourceUnknown, "", false},
+
+		// Garbage must not panic or match.
+		{"", fsm.TriggerSourceUnknown, "", false},
+		{"nope", fsm.TriggerSourceUnknown, "", false},
+		{"brake::on", fsm.TriggerSourceUnknown, "", false},
+		{"brake:middle:on", fsm.TriggerSourceUnknown, "", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.payload, func(t *testing.T) {
+			src, edge, ok := parseButtonPayload(tc.payload)
+			if ok != tc.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tc.wantOK)
+			}
+			if !ok {
+				return
+			}
+			if src != tc.wantSource {
+				t.Errorf("source = %s, want %s", src, tc.wantSource)
+			}
+			if edge != tc.wantEdge {
+				t.Errorf("edge = %q, want %q", edge, tc.wantEdge)
+			}
+		})
+	}
+}
+
+func TestParseBoolSetting(t *testing.T) {
+	truthy := []string{"true", "True", "TRUE", "1", "yes", "on", " true ", "YES"}
+	for _, v := range truthy {
+		if !parseBoolSetting(v) {
+			t.Errorf("parseBoolSetting(%q) = false, want true", v)
+		}
+	}
+	falsy := []string{"false", "0", "no", "off", "", "maybe", "2"}
+	for _, v := range falsy {
+		if parseBoolSetting(v) {
+			t.Errorf("parseBoolSetting(%q) = true, want false", v)
+		}
+	}
+}

--- a/internal/redis/subscribers_test.go
+++ b/internal/redis/subscribers_test.go
@@ -1,10 +1,36 @@
 package redis
 
 import (
+	"io"
+	"log/slog"
 	"testing"
 
 	"alarm-service/internal/fsm"
 )
+
+// fakeEventSink records events the subscriber emits without requiring a real
+// state machine. Implements the package-private eventSink interface.
+type fakeEventSink struct {
+	events []fsm.Event
+	state  fsm.State
+}
+
+func (f *fakeEventSink) SendEvent(e fsm.Event) { f.events = append(f.events, e) }
+func (f *fakeEventSink) State() fsm.State      { return f.state }
+
+// newTestSubscriber builds a Subscriber with only the fields the handlebar
+// handlers touch populated. Sufficient for exercising the baseline/
+// transition logic without hitting Redis.
+func newTestSubscriber() (*Subscriber, *fakeEventSink) {
+	sink := &fakeEventSink{}
+	s := &Subscriber{
+		log:              slog.New(slog.NewTextHandler(io.Discard, nil)),
+		sm:               sink,
+		handlebarEnabled: true,
+		buttonsEnabled:   true,
+	}
+	return s, sink
+}
 
 // parseButtonPayload must accept the payloads vehicle-service publishes on the
 // `buttons` channel and map them to the right TriggerSource. Unknown payloads
@@ -53,6 +79,110 @@ func TestParseButtonPayload(t *testing.T) {
 				t.Errorf("edge = %q, want %q", edge, tc.wantEdge)
 			}
 		})
+	}
+}
+
+// Handlebar lock baseline: the first callback (StartWithSync) must not emit,
+// even when the value is "unlocked" (rider parked without engaging the lock).
+func TestHandlebarLock_InitialSyncNoTrigger(t *testing.T) {
+	s, sink := newTestSubscriber()
+
+	if err := s.handleHandlebarLockField("unlocked"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(sink.events) != 0 {
+		t.Fatalf("expected no events on baseline capture, got %v", sink.events)
+	}
+	if s.handlebarLockLast != "unlocked" {
+		t.Errorf("baseline not captured, got %q", s.handlebarLockLast)
+	}
+}
+
+// Handlebar lock transition: only locked -> unlocked after baseline emits.
+func TestHandlebarLock_LockedToUnlockedTriggers(t *testing.T) {
+	s, sink := newTestSubscriber()
+
+	_ = s.handleHandlebarLockField("locked") // baseline
+	if err := s.handleHandlebarLockField("unlocked"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(sink.events) != 1 {
+		t.Fatalf("expected 1 event, got %d: %v", len(sink.events), sink.events)
+	}
+	ev, ok := sink.events[0].(fsm.InputTriggerEvent)
+	if !ok {
+		t.Fatalf("expected InputTriggerEvent, got %T", sink.events[0])
+	}
+	if ev.Source != fsm.TriggerSourceHandlebarLock {
+		t.Errorf("wrong source: %s", ev.Source)
+	}
+}
+
+// A second "unlocked" report after we already reported "unlocked" must not
+// emit a new trigger (no state change).
+func TestHandlebarLock_RepeatedUnlockedNoTrigger(t *testing.T) {
+	s, sink := newTestSubscriber()
+
+	_ = s.handleHandlebarLockField("unlocked") // baseline
+	_ = s.handleHandlebarLockField("unlocked") // spurious repeat
+	_ = s.handleHandlebarLockField("unlocked") // more noise
+
+	if len(sink.events) != 0 {
+		t.Fatalf("expected no events on repeats, got %v", sink.events)
+	}
+}
+
+// unlocked -> locked -> unlocked fires once on the second transition.
+func TestHandlebarLock_CycleTriggersOnce(t *testing.T) {
+	s, sink := newTestSubscriber()
+
+	_ = s.handleHandlebarLockField("unlocked") // baseline
+	_ = s.handleHandlebarLockField("locked")   // safe transition, no event
+	_ = s.handleHandlebarLockField("unlocked") // unsafe transition, event
+
+	if len(sink.events) != 1 {
+		t.Fatalf("expected 1 event, got %d: %v", len(sink.events), sink.events)
+	}
+}
+
+// handlebar trigger disabled via setting: transition happens but no event
+// is sent.
+func TestHandlebarLock_FlagDisabledSuppresses(t *testing.T) {
+	s, sink := newTestSubscriber()
+	s.handlebarEnabled = false
+
+	_ = s.handleHandlebarLockField("locked")
+	_ = s.handleHandlebarLockField("unlocked")
+
+	if len(sink.events) != 0 {
+		t.Fatalf("expected no events when handlebar disabled, got %v", sink.events)
+	}
+}
+
+// Handlebar position: same baseline/transition rules as the lock sensor.
+func TestHandlebarPosition_OffPlaceBaselineNoTrigger(t *testing.T) {
+	s, sink := newTestSubscriber()
+
+	_ = s.handleHandlebarPositionField("off-place")
+
+	if len(sink.events) != 0 {
+		t.Fatalf("expected no events on baseline, got %v", sink.events)
+	}
+}
+
+func TestHandlebarPosition_OnPlaceToOffPlaceTriggers(t *testing.T) {
+	s, sink := newTestSubscriber()
+
+	_ = s.handleHandlebarPositionField("on-place") // baseline
+	_ = s.handleHandlebarPositionField("off-place")
+
+	if len(sink.events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(sink.events))
+	}
+	ev := sink.events[0].(fsm.InputTriggerEvent)
+	if ev.Source != fsm.TriggerSourceHandlebarPosition {
+		t.Errorf("wrong source: %s", ev.Source)
 	}
 }
 


### PR DESCRIPTION
Adds handlebar lock/position, brake lever, and handlebar-button presses as tamper trigger sources alongside the existing motion + seatbox paths. Each source is togglable via a per-category settings flag. The Berlin-vibration "motion-off" preset becomes `alarm.trigger.motion=false`, and the scooter still responds to genuine physical manipulation.

Refs librescoot/librescoot#26 and the parent epic `librescoot-5d7p`. Pairs with librescoot/vehicle-service#24 (`feat/inputs-in-standby`) which exposes the kickstand/brake hash fields in Standby. This PR doesn't need it: the `buttons` PUBSUB channel already fires in every vehicle state today, and the handlebar lock/position fields were already unconditional.

## Beans

Implements four children of `librescoot-5d7p`:

- `librescoot-0679` ­- subscribe to `buttons` PUBSUB as tamper trigger source
- `librescoot-nor4` ­- subscribe to `handlebar:lock-sensor` and `handlebar:position` as tamper triggers
- `librescoot-u565` ­- per-source trigger enable flags + inputs-only preset
- `librescoot-2uyg` ­- configurable BMX sensitivity via settings hash

Plus the doc half of `librescoot-rq0w` (README note explaining why throttle isn't a trigger source; it's only visible as an ECU CAN payload, and the ECU is cut in Standby).

## Changes

- `internal/fsm/events.go`: `InputTriggerEvent`, `TriggerSource`, `TriggerSourceCategory`, `TriggerSourceSettingChangedEvent`, `SensitivityChangedEvent`, `ParseSensitivity`.
- `internal/fsm/state_machine.go`: `sensorArmed{Low,Medium,High}` variants, per-source enable flags, sensitivity field, tamper-trigger helper, handlers for the new events. Sensitivity changes in StateArmed re-apply the config without a state transition.
- `internal/fsm/transitions.go`: `InputTriggerEvent` mirrors `BMXInterruptEvent` transitions in `StateArmed`, `StateTriggerLevel1`, `StateWaitingMovement`.
- `internal/fsm/states.go`: `onEnterArmed` picks sensor config from current sensitivity.
- `internal/redis/subscribers.go`:
  - `OnField` handlers for `handlebar:lock-sensor` and `handlebar:position` that only trigger on a safe-to-unsafe transition observed after the initial sync. Scooters routinely park without engaging the handlebar lock, so "unlocked" is often the resting value. Triggering on `StartWithSync`'s initial delivery would fire on every service restart.
  - `OnField` for `alarm.trigger.{motion,buttons,handlebar}` and `alarm.sensitivity`.
  - `ipc.Subscribe` to the `buttons` channel with `parseButtonPayload` picking brake/horn/seatbox. Blinkers ignored.
  - Rejected events dropped at the subscriber so the FSM doesn't pay for them.
- `internal/fsm/state_machine_test.go`, `internal/redis/subscribers_test.go`: 14 new test cases covering input-trigger escalation, motion-disabled path, sensitivity reconfig in/out of armed, button payload parsing (incl. blinker-ignored and malformed), handlebar baseline suppression, and transition detection.
- `README.md`: settings reference, trigger source table, throttle exclusion rationale.

## Defaults and compatibility

- All three `alarm.trigger.*` flags default to `true`. No behavior change unless operators opt out.
- `alarm.sensitivity` defaults to `medium`, matching the existing hardcoded threshold (0x04).
- Existing `alarm.seatbox-trigger` unchanged, kept under its own name for continuity.

## Test plan

- [x] `make build` (ARM) clean
- [x] `go build ./...` clean
- [x] `go test ./...` all passing, including 14 new cases
- [x] Deployed to deep-blue (`alarm-service v0.10.0-2-g6ec9133`) and observed: no spurious handlebar triggers on startup, settings watchers fire cleanly, hair trigger at 1s enabled.
- [ ] Field test on deep-blue: lock scooter (Standby), verify alarm triggers on:
  - [ ] Brake lever pull (via `buttons` PUBSUB)
  - [ ] Handlebar lock sensor forced open (after engaging lock)
  - [ ] Handlebar moved off-place (after parking with bars turned)
- [ ] Field test: set `alarm.trigger.motion=false`, verify motion on a moving truck passby does NOT trigger while input-based triggers still work
- [ ] Field test: set `alarm.sensitivity=low`, verify armed threshold looser (fewer false positives on vibration); set to `high`, verify it tightens